### PR TITLE
multi value parameter can be written out in one line / avoid conversi…

### DIFF
--- a/pytomoatt/para.py
+++ b/pytomoatt/para.py
@@ -2,6 +2,7 @@ from ruamel.yaml import YAML
 from .utils.common import init_axis, str2val
 
 yaml = YAML()
+yaml.default_flow_style = True
 
 class ATTPara:
     """Class for read and write parameter file with ``yaml`` format
@@ -24,10 +25,10 @@ class ATTPara:
             self.input_params['domain']['n_rtp'],
         )
         return dep, lat, lon, dd, dt, dp
-    
+
     def update_param(self, key: str, value) -> None:
         """Update a parameter in the YAML file.
-        
+
         :param key: The key of parameter file to be set. Use '.' to separate the keys.
         :type key: str
         """

--- a/pytomoatt/utils/common.py
+++ b/pytomoatt/utils/common.py
@@ -136,21 +136,38 @@ def ignore_nan_3d(data):
     xidx = np.arange(data.shape[2])
     zz, xx, yy = np.meshgrid(zidx, yidx, xidx, indexing='ij')
     interpolated = griddata(
-        points, values, 
-        (zz, xx, yy), 
+        points, values,
+        (zz, xx, yy),
         method='nearest'
     )
     result = interpolated.reshape(data.shape)
     return result
 
 def str2val(str_val):
+    # single value handling
+    # return integer
     try:
         return int(str_val)
     except ValueError:
-        try:
-            return float(str_val)
-        except ValueError:
-            try:
-                return [float(v) for v in str_val.strip('[]').split(',')]
-            except ValueError:
-                return str_val
+        pass
+
+    # return float
+    try:
+        return float(str_val)
+    except ValueError:
+        pass
+
+    # list values handling
+    # return list of integer
+    try:
+        return [int(v) for v in str_val.strip('[]').split(',')]
+    except ValueError:
+        pass
+
+    # return list of float
+    try:
+        return [float(v) for v in str_val.strip('[]').split(',')]
+    except ValueError:
+        pass
+
+    return str_val


### PR DESCRIPTION
…on from integer list to float list

(I am recreating this PR in stead of what I wrongly created on the master branch)

Hi @xumi1993 , I modified a bit of parameter handling as the title. Can you review and merge it?

Otherwise, TomoATT gets an error "Error parsing YAML value for key: ndiv_rtp. yaml-cpp: error at line 32, column 5: bad conversion", when the parallel.ndiv_rtp is updated by pytomoatt and TomoATT read this updated input file.